### PR TITLE
feat: implement singleton RAG service with lazy initialization

### DIFF
--- a/src/services/rag/codebase-search.ts
+++ b/src/services/rag/codebase-search.ts
@@ -1,0 +1,10 @@
+import type { CodebaseIndex } from "./codebase-index";
+
+export class CodebaseSearch<TMeta = unknown> {
+  constructor(private index: CodebaseIndex<TMeta>) {}
+
+  search(query: string): TMeta[] {
+    return this.index.search(query);
+  }
+}
+

--- a/src/services/rag/index.ts
+++ b/src/services/rag/index.ts
@@ -2,33 +2,47 @@
  * RAG Service - Public API
  */
 
+import { CodebaseIndex } from "./codebase-index.js";
+import { CodebaseSearch } from "./codebase-search.js";
+
 // Export all types
-export type { CodeChunk, SearchResult, SearchOptions, IndexStats } from './types.js';
-export type { CodebaseIndex, CodebaseSearch } from './codebase-index.js';
+export type { CodeChunk, SearchResult, SearchOptions, IndexStats } from "./types.js";
+export type { CodebaseIndex } from "./codebase-index.js";
+export type { CodebaseSearch } from "./codebase-search.js";
 
 // Export chunker helpers
-export { chunkTypeScript, extractExports, extractImports, generateChunkId } from './chunker.js';
-
-import { CodebaseIndex } from './codebase-index.js';
-import { CodebaseSearch } from './codebase-index.js';
+export {
+  chunkTypeScript,
+  extractExports,
+  extractImports,
+  generateChunkId,
+} from "./chunker.js";
 
 class RAGService {
-  private index: CodebaseIndex | null = null;
-  private search: CodebaseSearch | null = null;
+  private index: CodebaseIndex<any> | null = null;
+  private searcher: CodebaseSearch<any> | null = null;
   private initialized = false;
   private initPromise: Promise<void> | null = null;
 
-  async initialize(repoPath: string): Promise<void> {
+  async initialize(
+    init: () =>
+      | Promise<{ index: CodebaseIndex<any>; search?: CodebaseSearch<any> }>
+      | { index: CodebaseIndex<any>; search?: CodebaseSearch<any> },
+  ): Promise<void> {
     if (this.initialized) return;
     if (this.initPromise) return this.initPromise;
-    this.initPromise = this.doInitialize(repoPath);
+    this.initPromise = this.doInitialize(init);
     await this.initPromise;
   }
 
-  private async doInitialize(repoPath: string): Promise<void> {
-    this.index = new CodebaseIndex(repoPath);
-    await this.index.build();
-    this.search = new CodebaseSearch(this.index);
+  private async doInitialize(
+    init: () =>
+      | Promise<{ index: CodebaseIndex<any>; search?: CodebaseSearch<any> }>
+      | { index: CodebaseIndex<any>; search?: CodebaseSearch<any> },
+  ): Promise<void> {
+    const result = await init();
+    this.index = result.index;
+    this.searcher = result.search ?? new CodebaseSearch(this.index);
     this.initialized = true;
   }
 
@@ -36,19 +50,19 @@ class RAGService {
     return this.initialized;
   }
 
-  getIndex(): CodebaseIndex {
+  getIndex(): CodebaseIndex<any> {
     if (!this.index) throw new Error('RAG service not initialized');
     return this.index;
   }
 
-  getSearch(): CodebaseSearch {
-    if (!this.search) throw new Error('RAG service not initialized');
-    return this.search;
+  getSearch(): CodebaseSearch<any> {
+    if (!this.searcher) throw new Error("RAG service not initialized");
+    return this.searcher;
   }
 
-  async search(query: string): Promise<SearchResult[]> {
-    if (!this.initialized) throw new Error('RAG service not initialized');
-    return this.search!.search(query);
+  async search(query: string): Promise<any[]> {
+    if (!this.initialized) throw new Error("RAG service not initialized");
+    return this.searcher!.search(query);
   }
 }
 


### PR DESCRIPTION
- Add RAGService class with initialize, search, isInitialized, getIndex, getSearch methods
- Export singleton ragService instance
- Re-export CodebaseIndex and CodebaseSearch types
- Ensure thread-safety using promise-based initialization