### PR TITLE
feat: temporal validity tracker (in-memory)

### DIFF
--- a/src/core/knowledge-graph/temporal-tracker.test.ts
+++ b/src/core/knowledge-graph/temporal-tracker.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { TemporalTracker } from "./temporal-tracker";
+import type { ResolvedEntity } from "./types";
+
+function entity(partial: Partial<ResolvedEntity>): ResolvedEntity {
+  return {
+    id: partial.id ?? "id",
+    canonicalId: partial.canonicalId ?? "canon",
+    name: partial.name ?? "Name",
+    entityType: partial.entityType ?? "function",
+    filePath: partial.filePath ?? "src/a.ts",
+    signature: partial.signature ?? null,
+    content: partial.content ?? null,
+    metadata: partial.metadata ?? undefined,
+    aliases: partial.aliases ?? [],
+    relationships: partial.relationships ?? [],
+    mergedFrom: partial.mergedFrom ?? ["id"],
+  };
+}
+
+describe("TemporalTracker", () => {
+  it("records first version and returns current", async () => {
+    const tracker = new TemporalTracker();
+    const v1 = await tracker.recordVersion(entity({ signature: "a()" }), "sha1");
+    expect(v1.version).toBe(1);
+    expect(v1.validUntil).toBeNull();
+    const current = await tracker.getCurrent("canon");
+    expect(current?.id).toBe(v1.id);
+  });
+
+  it("creates a new version when entity changes", async () => {
+    const tracker = new TemporalTracker();
+    const v1 = await tracker.recordVersion(entity({ signature: "a()" }), "sha1");
+    await new Promise((r) => setTimeout(r, 5));
+    const v2 = await tracker.recordVersion(entity({ signature: "a(x)" }), "sha2");
+    expect(v2.version).toBe(2);
+    expect(v2.supersedes).toBe(v1.id);
+    expect(v1.validUntil).not.toBeNull();
+    expect(v1.supersededBy).toBe(v2.id);
+    expect((await tracker.getCurrent("canon"))?.id).toBe(v2.id);
+  });
+
+  it("returns version at point in time", async () => {
+    const tracker = new TemporalTracker();
+    const t0 = new Date();
+    const v1 = await tracker.recordVersion(entity({ signature: "a()" }), "sha1");
+    await new Promise((r) => setTimeout(r, 5));
+    const split = new Date();
+    const v2 = await tracker.recordVersion(entity({ signature: "a(x)" }), "sha2");
+
+    expect((await tracker.getAtTime("canon", t0))?.id).toBe(v1.id);
+    expect((await tracker.getAtTime("canon", split))?.id).toBe(v2.id);
+  });
+
+  it("can invalidate an entity", async () => {
+    const tracker = new TemporalTracker();
+    const v1 = await tracker.recordVersion(entity({ signature: "a()" }), "sha1");
+    await tracker.invalidate(v1.id);
+    expect(v1.validUntil).not.toBeNull();
+  });
+});
+

--- a/src/core/knowledge-graph/temporal-tracker.ts
+++ b/src/core/knowledge-graph/temporal-tracker.ts
@@ -1,0 +1,129 @@
+import { createHash } from "node:crypto";
+import type { ResolvedEntity } from "./types";
+
+export interface TemporalEntity {
+  id: string;
+  canonicalId: string;
+  validFrom: Date;
+  validUntil: Date | null;
+  commitSha: string;
+  version: number;
+  supersedes?: string;
+  supersededBy?: string;
+  entity: ResolvedEntity;
+  entityHash: string;
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || value === undefined) return String(value);
+  if (typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys
+    .map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`)
+    .join(",")}}`;
+}
+
+function entityToComparable(entity: ResolvedEntity): Record<string, unknown> {
+  return {
+    canonicalId: entity.canonicalId,
+    id: entity.id,
+    name: entity.name,
+    entityType: entity.entityType,
+    filePath: entity.filePath ?? null,
+    signature: entity.signature ?? null,
+    content: entity.content ?? null,
+    metadata: entity.metadata ?? null,
+    aliases: entity.aliases ?? [],
+    relationships: entity.relationships ?? [],
+    mergedFrom: entity.mergedFrom ?? [],
+  };
+}
+
+function computeEntityHash(entity: ResolvedEntity): string {
+  return sha256(stableStringify(entityToComparable(entity)));
+}
+
+function newId(): string {
+  // Not a UUID, but stable-enough for in-memory use
+  return sha256(`${Date.now()}:${Math.random()}`).slice(0, 32);
+}
+
+export class TemporalTracker {
+  private byCanonical = new Map<string, TemporalEntity[]>();
+  private byId = new Map<string, TemporalEntity>();
+
+  async recordVersion(entity: ResolvedEntity, commitSha: string): Promise<TemporalEntity> {
+    const now = new Date();
+    const canonicalId = entity.canonicalId;
+    const versions = this.byCanonical.get(canonicalId) ?? [];
+    const current = [...versions].reverse().find((v) => v.validUntil === null) ?? null;
+
+    const entityHash = computeEntityHash(entity);
+    if (current && current.entityHash === entityHash) {
+      return current;
+    }
+
+    const next: TemporalEntity = {
+      id: newId(),
+      canonicalId,
+      validFrom: now,
+      validUntil: null,
+      commitSha,
+      version: (versions[versions.length - 1]?.version ?? 0) + 1,
+      supersedes: current?.id,
+      entity,
+      entityHash,
+    };
+
+    if (current) {
+      current.validUntil = now;
+      current.supersededBy = next.id;
+      this.byId.set(current.id, current);
+    }
+
+    versions.push(next);
+    this.byCanonical.set(canonicalId, versions);
+    this.byId.set(next.id, next);
+    return next;
+  }
+
+  async getCurrent(canonicalId: string): Promise<TemporalEntity | null> {
+    const versions = this.byCanonical.get(canonicalId) ?? [];
+    for (let i = versions.length - 1; i >= 0; i--) {
+      const v = versions[i]!;
+      if (v.validUntil === null) return v;
+    }
+    return null;
+  }
+
+  async getAtTime(canonicalId: string, timestamp: Date): Promise<TemporalEntity | null> {
+    const versions = this.byCanonical.get(canonicalId) ?? [];
+    const t = timestamp.getTime();
+    for (let i = versions.length - 1; i >= 0; i--) {
+      const v = versions[i]!;
+      const from = v.validFrom.getTime();
+      const until = v.validUntil ? v.validUntil.getTime() : Infinity;
+      if (t >= from && t < until) return v;
+    }
+    return null;
+  }
+
+  async getHistory(canonicalId: string): Promise<TemporalEntity[]> {
+    return [...(this.byCanonical.get(canonicalId) ?? [])];
+  }
+
+  async invalidate(entityId: string, supersededBy?: string): Promise<void> {
+    const v = this.byId.get(entityId);
+    if (!v) return;
+    if (v.validUntil === null) v.validUntil = new Date();
+    if (supersededBy) v.supersededBy = supersededBy;
+    this.byId.set(entityId, v);
+  }
+}
+


### PR DESCRIPTION
Closes #232.

- Adds src/core/knowledge-graph/temporal-tracker.ts implementing TemporalEntity versioning + point-in-time queries.
- Adds unit tests src/core/knowledge-graph/temporal-tracker.test.ts.