### PR TITLE
feat: multi-hop retrieval for knowledge graph

### DIFF
--- a/src/core/knowledge-graph/multi-hop-retriever.test.ts
+++ b/src/core/knowledge-graph/multi-hop-retriever.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "bun:test";
+import { MultiHopRetriever, type TemporalRelationship } from "./multi-hop-retriever";
+import type { TemporalEntity } from "./temporal-tracker";
+import type { ResolvedEntity } from "./types";
+
+function te(id: string, canonicalId: string): TemporalEntity {
+  const entity: ResolvedEntity = {
+    id,
+    canonicalId,
+    name: id,
+    entityType: "function",
+    filePath: "src/a.ts",
+    signature: null,
+    content: null,
+    aliases: [],
+    relationships: [],
+    mergedFrom: [id],
+  };
+  return {
+    id,
+    canonicalId,
+    validFrom: new Date(0),
+    validUntil: null,
+    commitSha: "sha",
+    version: 1,
+    entity,
+    entityHash: "hash",
+  };
+}
+
+function rel(
+  id: string,
+  sourceId: string,
+  targetId: string,
+  relationshipType: TemporalRelationship["relationshipType"],
+): TemporalRelationship {
+  return {
+    id,
+    sourceId,
+    targetId,
+    relationshipType,
+    validFrom: new Date(0),
+    validUntil: null,
+  };
+}
+
+describe("MultiHopRetriever", () => {
+  it("traverses outbound dependencies", async () => {
+    const a = te("a", "ca");
+    const b = te("b", "cb");
+    const c = te("c", "cc");
+    const retriever = new MultiHopRetriever({
+      entities: [a, b, c],
+      relationships: [rel("r1", "a", "b", "uses"), rel("r2", "b", "c", "imports")],
+    });
+
+    const results = await retriever.findDependencies("a", 3);
+    expect(results.some((r) => r.entity.id === "b")).toBe(true);
+    expect(results.some((r) => r.entity.id === "c")).toBe(true);
+  });
+
+  it("traverses inbound impact using used_by inverse", async () => {
+    const a = te("a", "ca");
+    const b = te("b", "cb");
+    const retriever = new MultiHopRetriever({
+      entities: [a, b],
+      relationships: [rel("r1", "b", "a", "uses")],
+    });
+
+    const results = await retriever.findImpact("a", 1);
+    const bHit = results.find((r) => r.entity.id === "b");
+    expect(bHit?.path[0]?.relationship).toBe("used_by");
+  });
+
+  it("finds path between entities", async () => {
+    const a = te("a", "ca");
+    const b = te("b", "cb");
+    const c = te("c", "cc");
+    const retriever = new MultiHopRetriever({
+      entities: [a, b, c],
+      relationships: [rel("r1", "a", "b", "imports"), rel("r2", "b", "c", "uses")],
+    });
+
+    const path = await retriever.findPath("a", "c");
+    expect(path).not.toBeNull();
+    expect(path?.hopDistance).toBe(2);
+  });
+});
+

--- a/src/core/knowledge-graph/multi-hop-retriever.ts
+++ b/src/core/knowledge-graph/multi-hop-retriever.ts
@@ -1,0 +1,216 @@
+import type { TemporalEntity } from "./temporal-tracker";
+
+export type RelationshipType =
+  | "imports"
+  | "exports"
+  | "extends"
+  | "implements"
+  | "uses"
+  | "used_by"
+  | "contains"
+  | "depends_on"
+  | "supersedes";
+
+export interface HopQuery {
+  startEntityId: string;
+  relationshipTypes: RelationshipType[];
+  direction: "outbound" | "inbound" | "both";
+  maxHops?: number;
+  includeInvalid?: boolean;
+  asOfTime?: Date;
+}
+
+export interface HopPathEdge {
+  relationship: RelationshipType;
+  fromEntity: string;
+  toEntity: string;
+}
+
+export interface HopResult {
+  entity: TemporalEntity;
+  hopDistance: number;
+  path: HopPathEdge[];
+}
+
+export interface TemporalRelationship {
+  id: string;
+  sourceId: string;
+  targetId: string;
+  relationshipType: Exclude<RelationshipType, "used_by">;
+  validFrom: Date;
+  validUntil: Date | null;
+}
+
+function isValidAt(
+  validFrom: Date,
+  validUntil: Date | null,
+  at: Date | null,
+): boolean {
+  if (!at) return validUntil === null;
+  const t = at.getTime();
+  const from = validFrom.getTime();
+  const until = validUntil ? validUntil.getTime() : Infinity;
+  return t >= from && t < until;
+}
+
+function inverseType(t: RelationshipType): RelationshipType {
+  if (t === "uses") return "used_by";
+  return t;
+}
+
+export class MultiHopRetriever {
+  private entities = new Map<string, TemporalEntity[]>();
+  private relationships: TemporalRelationship[] = [];
+
+  constructor(opts?: {
+    entities?: TemporalEntity[];
+    relationships?: TemporalRelationship[];
+  }) {
+    if (opts?.entities) {
+      for (const e of opts.entities) {
+        const arr = this.entities.get(e.canonicalId) ?? [];
+        arr.push(e);
+        this.entities.set(e.canonicalId, arr);
+      }
+    }
+    if (opts?.relationships) this.relationships = opts.relationships;
+  }
+
+  private resolveEntity(
+    entityId: string,
+    asOfTime: Date | null,
+    includeInvalid: boolean,
+  ): TemporalEntity | null {
+    // entityId refers to TemporalEntity.id
+    for (const versions of this.entities.values()) {
+      for (const v of versions) {
+        if (v.id !== entityId) continue;
+        if (asOfTime) {
+          if (!isValidAt(v.validFrom, v.validUntil, asOfTime)) return null;
+        } else if (!includeInvalid && v.validUntil !== null) {
+          return null;
+        }
+        return v;
+      }
+    }
+    return null;
+  }
+
+  private adjacent(
+    fromId: string,
+    direction: HopQuery["direction"],
+    asOfTime: Date | null,
+    includeInvalid: boolean,
+    allowed: Set<RelationshipType>,
+  ): Array<{ toId: string; rel: RelationshipType }> {
+    const out: Array<{ toId: string; rel: RelationshipType }> = [];
+
+    const add = (toId: string, rel: RelationshipType) => {
+      if (!allowed.has(rel)) return;
+      if (!this.resolveEntity(toId, asOfTime, includeInvalid)) return;
+      out.push({ toId, rel });
+    };
+
+    for (const r of this.relationships) {
+      if (!isValidAt(r.validFrom, r.validUntil, asOfTime)) continue;
+
+      if (direction === "outbound" || direction === "both") {
+        if (r.sourceId === fromId) add(r.targetId, r.relationshipType);
+      }
+      if (direction === "inbound" || direction === "both") {
+        if (r.targetId === fromId) add(r.sourceId, inverseType(r.relationshipType));
+      }
+    }
+
+    return out;
+  }
+
+  async traverse(query: HopQuery): Promise<HopResult[]> {
+    const maxHops = query.maxHops ?? 3;
+    const includeInvalid = query.includeInvalid ?? false;
+    const asOfTime = query.asOfTime ?? null;
+    const allowed = new Set<RelationshipType>(query.relationshipTypes);
+
+    const start = this.resolveEntity(query.startEntityId, asOfTime, includeInvalid);
+    if (!start) return [];
+
+    const results: HopResult[] = [
+      { entity: start, hopDistance: 0, path: [] },
+    ];
+
+    const visited = new Set<string>([start.id]);
+    const queue: Array<{ id: string; dist: number; path: HopPathEdge[] }> = [
+      { id: start.id, dist: 0, path: [] },
+    ];
+
+    while (queue.length) {
+      const cur = queue.shift()!;
+      if (cur.dist >= maxHops) continue;
+
+      const neigh = this.adjacent(
+        cur.id,
+        query.direction,
+        asOfTime,
+        includeInvalid,
+        allowed,
+      );
+
+      for (const n of neigh) {
+        if (visited.has(n.toId)) continue;
+        visited.add(n.toId);
+        const ent = this.resolveEntity(n.toId, asOfTime, includeInvalid);
+        if (!ent) continue;
+        const nextPath = [
+          ...cur.path,
+          { relationship: n.rel, fromEntity: cur.id, toEntity: n.toId },
+        ];
+        results.push({ entity: ent, hopDistance: cur.dist + 1, path: nextPath });
+        queue.push({ id: n.toId, dist: cur.dist + 1, path: nextPath });
+      }
+    }
+
+    return results;
+  }
+
+  async findImpact(entityId: string, maxHops: number = 3): Promise<HopResult[]> {
+    return this.traverse({
+      startEntityId: entityId,
+      relationshipTypes: ["used_by", "uses", "imports", "extends", "implements"],
+      direction: "inbound",
+      maxHops,
+      includeInvalid: false,
+    });
+  }
+
+  async findDependencies(entityId: string, maxHops: number = 3): Promise<HopResult[]> {
+    return this.traverse({
+      startEntityId: entityId,
+      relationshipTypes: ["uses", "imports", "extends", "implements", "supersedes"],
+      direction: "outbound",
+      maxHops,
+      includeInvalid: false,
+    });
+  }
+
+  async findPath(fromId: string, toId: string): Promise<HopResult | null> {
+    const all = await this.traverse({
+      startEntityId: fromId,
+      relationshipTypes: [
+        "imports",
+        "exports",
+        "extends",
+        "implements",
+        "uses",
+        "used_by",
+        "contains",
+        "depends_on",
+        "supersedes",
+      ],
+      direction: "both",
+      maxHops: 6,
+      includeInvalid: false,
+    });
+    return all.find((r) => r.entity.id === toId) ?? null;
+  }
+}
+


### PR DESCRIPTION
Closes #234.

- Adds src/core/knowledge-graph/multi-hop-retriever.ts implementing BFS traversal with cycle detection and direction/relationship filters.
- Adds unit tests src/core/knowledge-graph/multi-hop-retriever.test.ts.