### PR TITLE
feat: invalidation agent for knowledge graph

### DIFF
--- a/src/agents/invalidation-agent.test.ts
+++ b/src/agents/invalidation-agent.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+import { detectInvalidations } from "./invalidation-agent";
+import type { TemporalEntity } from "../core/knowledge-graph/temporal-tracker";
+import type { ResolvedEntity } from "../core/knowledge-graph/types";
+
+function temporalEntity(overrides: Partial<TemporalEntity>): TemporalEntity {
+  const entity: ResolvedEntity = {
+    id: overrides.entity?.id ?? "new",
+    canonicalId: overrides.canonicalId ?? "canon",
+    name: overrides.entity?.name ?? "Name",
+    entityType: overrides.entity?.entityType ?? "function",
+    filePath: overrides.entity?.filePath ?? "src/a.ts",
+    signature: overrides.entity?.signature ?? null,
+    content: overrides.entity?.content ?? null,
+    aliases: [],
+    relationships: overrides.entity?.relationships ?? [],
+    mergedFrom: ["x"],
+  };
+  return {
+    id: overrides.id ?? "old",
+    canonicalId: overrides.canonicalId ?? "canon",
+    validFrom: overrides.validFrom ?? new Date(0),
+    validUntil: overrides.validUntil ?? null,
+    commitSha: overrides.commitSha ?? "sha0",
+    version: overrides.version ?? 1,
+    entity,
+    entityHash: overrides.entityHash ?? "hash",
+  };
+}
+
+describe("detectInvalidations", () => {
+  it("detects deletions", () => {
+    const out = detectInvalidations({
+      oldEntities: [temporalEntity({ id: "e1", canonicalId: "c1" })],
+      newEntities: [],
+      commitSha: "sha1",
+    });
+    expect(out.invalidations[0]?.reason).toBe("deleted");
+  });
+
+  it("detects signature change", () => {
+    const oldE = temporalEntity({
+      id: "e1",
+      canonicalId: "c1",
+      entity: { ...(temporalEntity({}).entity as any), signature: "a()" },
+    });
+    const newE: ResolvedEntity = {
+      ...oldE.entity,
+      id: "new1",
+      signature: "a(x)",
+    };
+    const out = detectInvalidations({
+      oldEntities: [oldE],
+      newEntities: [newE],
+      commitSha: "sha2",
+    });
+    expect(out.invalidations[0]?.reason).toBe("signature_change");
+    expect(out.updates.length).toBe(1);
+  });
+
+  it("detects superseded content", () => {
+    const oldE = temporalEntity({
+      id: "e1",
+      canonicalId: "c1",
+      entity: { ...(temporalEntity({}).entity as any), content: "a" },
+    });
+    const newE: ResolvedEntity = {
+      ...oldE.entity,
+      id: "new1",
+      content: "b",
+    };
+    const out = detectInvalidations({
+      oldEntities: [oldE],
+      newEntities: [newE],
+      commitSha: "sha3",
+    });
+    expect(out.invalidations[0]?.reason).toBe("superseded");
+  });
+});
+

--- a/src/agents/invalidation-agent.ts
+++ b/src/agents/invalidation-agent.ts
@@ -1,0 +1,152 @@
+import { BaseAgent } from "./base";
+import type { ResolvedEntity } from "../core/knowledge-graph/types";
+import type { TemporalEntity } from "../core/knowledge-graph/temporal-tracker";
+
+export type InvalidationReason =
+  | "deleted"
+  | "superseded"
+  | "signature_change"
+  | "semantic_change"
+  | "cascade"
+  | "manual";
+
+export interface InvalidationEvent {
+  entityId: string;
+  reason: InvalidationReason;
+  supersededBy?: string;
+  detectedAt: Date;
+  commitSha: string;
+  confidence: number;
+  details: string;
+}
+
+export interface InvalidationInput {
+  oldEntities: TemporalEntity[];
+  newEntities: ResolvedEntity[];
+  commitSha: string;
+  cascadeDepth?: number;
+}
+
+export interface InvalidationOutput {
+  invalidations: InvalidationEvent[];
+  updates: ResolvedEntity[];
+  unchanged: string[];
+}
+
+function normalizeEntityKey(e: { canonicalId: string }): string {
+  return e.canonicalId;
+}
+
+function comparableEntity(e: ResolvedEntity): string {
+  return JSON.stringify({
+    canonicalId: e.canonicalId,
+    name: e.name,
+    entityType: e.entityType,
+    filePath: e.filePath ?? null,
+    signature: e.signature ?? null,
+    content: e.content ?? null,
+  });
+}
+
+function comparableTemporalEntity(e: TemporalEntity): string {
+  return comparableEntity(e.entity);
+}
+
+export function detectInvalidations(input: InvalidationInput): InvalidationOutput {
+  const now = new Date();
+  const cascadeDepth = input.cascadeDepth ?? 1;
+
+  const currentOld = input.oldEntities.filter((e) => e.validUntil === null);
+  const oldByKey = new Map<string, TemporalEntity>(
+    currentOld.map((e) => [normalizeEntityKey(e), e]),
+  );
+  const newByKey = new Map<string, ResolvedEntity>(
+    input.newEntities.map((e) => [normalizeEntityKey(e), e]),
+  );
+
+  const invalidations: InvalidationEvent[] = [];
+  const updates: ResolvedEntity[] = [];
+  const unchanged: string[] = [];
+
+  for (const [key, oldEnt] of oldByKey.entries()) {
+    const next = newByKey.get(key);
+    if (!next) {
+      invalidations.push({
+        entityId: oldEnt.id,
+        reason: "deleted",
+        detectedAt: now,
+        commitSha: input.commitSha,
+        confidence: 1,
+        details: "Entity no longer present in new extraction set.",
+      });
+      continue;
+    }
+
+    const oldSig = oldEnt.entity.signature ?? null;
+    const newSig = next.signature ?? null;
+
+    if (oldSig && newSig && oldSig !== newSig) {
+      invalidations.push({
+        entityId: oldEnt.id,
+        reason: "signature_change",
+        supersededBy: next.id,
+        detectedAt: now,
+        commitSha: input.commitSha,
+        confidence: 1,
+        details: `Signature changed from "${oldSig}" to "${newSig}".`,
+      });
+      updates.push(next);
+      continue;
+    }
+
+    if (comparableTemporalEntity(oldEnt) !== comparableEntity(next)) {
+      invalidations.push({
+        entityId: oldEnt.id,
+        reason: "superseded",
+        supersededBy: next.id,
+        detectedAt: now,
+        commitSha: input.commitSha,
+        confidence: 0.9,
+        details: "Entity content differs from current version.",
+      });
+      updates.push(next);
+      continue;
+    }
+
+    unchanged.push(oldEnt.id);
+  }
+
+  // Cascade invalidations for direct dependencies (best-effort)
+  if (cascadeDepth > 0 && invalidations.length > 0) {
+    const invalidatedIds = new Set(invalidations.map((i) => i.entityId));
+    for (const oldEnt of currentOld) {
+      if (invalidatedIds.has(oldEnt.id)) continue;
+      const dependsOn = (oldEnt.entity.relationships ?? [])
+        .filter((r) => r.type === "uses" || r.type === "imports")
+        .map((r) => r.targetId);
+      if (dependsOn.some((id) => invalidatedIds.has(id))) {
+        invalidations.push({
+          entityId: oldEnt.id,
+          reason: "cascade",
+          detectedAt: now,
+          commitSha: input.commitSha,
+          confidence: 0.6,
+          details: "Dependency was invalidated; review needed.",
+        });
+      }
+    }
+  }
+
+  return { invalidations, updates, unchanged };
+}
+
+/**
+ * InvalidationAgent wraps invalidation detection and can be extended to use LLM
+ * for semantic_change detection in the future.
+ */
+export class InvalidationAgent extends BaseAgent<InvalidationInput, InvalidationOutput> {
+  async run(input: InvalidationInput): Promise<InvalidationOutput> {
+    return detectInvalidations(input);
+  }
+}
+


### PR DESCRIPTION
Closes #233.

- Adds src/agents/invalidation-agent.ts with InvalidationEvent types + detectInvalidations().
- Adds unit tests src/agents/invalidation-agent.test.ts.