### PR TITLE
feat: knowledge graph sync skeleton (webhook + API)

### DIFF
--- a/src/core/knowledge-graph/sync-service.test.ts
+++ b/src/core/knowledge-graph/sync-service.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import { knowledgeGraphSync } from "./sync-service";
+
+describe("KnowledgeGraphSyncService", () => {
+  it("returns pending by default when DB not configured", async () => {
+    const originalDatabaseUrl = process.env.DATABASE_URL;
+    delete process.env.DATABASE_URL;
+    const status = await knowledgeGraphSync.getStatus("owner/repo");
+    expect(status.repoFullName).toBe("owner/repo");
+    expect(status.status).toBe("pending");
+    if (originalDatabaseUrl) process.env.DATABASE_URL = originalDatabaseUrl;
+  });
+});

--- a/src/core/knowledge-graph/sync-service.ts
+++ b/src/core/knowledge-graph/sync-service.ts
@@ -1,0 +1,256 @@
+import { getDb } from "../../integrations/db";
+
+export type SyncStatus = "pending" | "syncing" | "synced" | "failed";
+
+export interface SyncState {
+  repoFullName: string;
+  status: SyncStatus;
+  lastCommitSha: string | null;
+  lastSyncAt: Date | null;
+  entityCount: number;
+  errorMessage?: string;
+}
+
+export interface IncrementalSyncInput {
+  repoFullName: string;
+  commitSha: string;
+  changedFiles: string[];
+}
+
+export interface FullSyncInput {
+  repoFullName: string;
+  commitSha?: string | null;
+}
+
+function isEnabled(): boolean {
+  const v = process.env.ENABLE_KNOWLEDGE_GRAPH_SYNC;
+  return v === "1" || v?.toLowerCase() === "true" || v?.toLowerCase() === "yes";
+}
+
+function hasDatabase(): boolean {
+  return !!process.env.DATABASE_URL;
+}
+
+function isPostgresRelationMissing(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const code = (error as any).code;
+  return code === "42P01";
+}
+
+class InMemorySyncStore {
+  private states = new Map<string, SyncState>();
+
+  get(repoFullName: string): SyncState | null {
+    return this.states.get(repoFullName) ?? null;
+  }
+
+  set(state: SyncState): void {
+    this.states.set(state.repoFullName, state);
+  }
+}
+
+export class KnowledgeGraphSyncService {
+  private memory = new InMemorySyncStore();
+
+  enabled(): boolean {
+    return isEnabled();
+  }
+
+  async getStatus(repoFullName: string): Promise<SyncState> {
+    const mem = this.memory.get(repoFullName);
+    if (!hasDatabase()) {
+      return (
+        mem ?? {
+          repoFullName,
+          status: "pending",
+          lastCommitSha: null,
+          lastSyncAt: null,
+          entityCount: 0,
+        }
+      );
+    }
+
+    let row: any | undefined;
+    try {
+      const sql = getDb();
+      [row] = await sql`
+        SELECT
+          repo_full_name,
+          status,
+          last_commit_sha,
+          last_sync_at,
+          entity_count,
+          error_message
+        FROM knowledge_graph_sync
+        WHERE repo_full_name = ${repoFullName}
+        LIMIT 1
+      `;
+    } catch (error) {
+      if (isPostgresRelationMissing(error)) {
+        return (
+          mem ?? {
+            repoFullName,
+            status: "pending",
+            lastCommitSha: null,
+            lastSyncAt: null,
+            entityCount: 0,
+          }
+        );
+      }
+      console.warn("[KnowledgeGraphSync] getStatus failed; falling back to memory", error);
+      return (
+        mem ?? {
+          repoFullName,
+          status: "pending",
+          lastCommitSha: null,
+          lastSyncAt: null,
+          entityCount: 0,
+        }
+      );
+    }
+
+    if (!row) {
+      return (
+        mem ?? {
+          repoFullName,
+          status: "pending",
+          lastCommitSha: null,
+          lastSyncAt: null,
+          entityCount: 0,
+        }
+      );
+    }
+
+    return {
+      repoFullName: row.repo_full_name,
+      status: row.status,
+      lastCommitSha: row.last_commit_sha ?? null,
+      lastSyncAt: row.last_sync_at ? new Date(row.last_sync_at) : null,
+      entityCount: row.entity_count ?? 0,
+      errorMessage: row.error_message ?? undefined,
+    };
+  }
+
+  async listEntities(repoFullName: string, limit: number = 200): Promise<any[]> {
+    if (!hasDatabase()) return [];
+    try {
+      const sql = getDb();
+      const rows = await sql`
+        SELECT
+          id,
+          canonical_id,
+          entity_type,
+          name,
+          file_path,
+          signature,
+          valid_from,
+          valid_until,
+          commit_sha,
+          version,
+          entity_data
+        FROM knowledge_entities
+        WHERE repo_full_name = ${repoFullName}
+        ORDER BY valid_from DESC
+        LIMIT ${limit}
+      `;
+      return rows.map((r) => ({
+        id: r.id,
+        canonicalId: r.canonical_id,
+        entityType: r.entity_type,
+        name: r.name,
+        filePath: r.file_path,
+        signature: r.signature,
+        validFrom: r.valid_from,
+        validUntil: r.valid_until,
+        commitSha: r.commit_sha,
+        version: r.version,
+        entityData: r.entity_data,
+      }));
+    } catch (error) {
+      if (isPostgresRelationMissing(error)) return [];
+      console.warn(
+        "[KnowledgeGraphSync] listEntities failed; returning empty result",
+        error,
+      );
+      return [];
+    }
+  }
+
+  async triggerFullSync(input: FullSyncInput): Promise<void> {
+    if (!this.enabled()) return;
+    await this.setStatus({
+      repoFullName: input.repoFullName,
+      status: "syncing",
+      lastCommitSha: input.commitSha ?? null,
+      lastSyncAt: null,
+      entityCount: 0,
+    });
+
+    // Placeholder: actual extraction/resolution pipeline will be wired in later.
+    await this.setStatus({
+      repoFullName: input.repoFullName,
+      status: "synced",
+      lastCommitSha: input.commitSha ?? null,
+      lastSyncAt: new Date(),
+      entityCount: 0,
+    });
+  }
+
+  async triggerIncrementalSync(input: IncrementalSyncInput): Promise<void> {
+    if (!this.enabled()) return;
+    const prev = await this.getStatus(input.repoFullName);
+
+    await this.setStatus({
+      ...prev,
+      status: "syncing",
+      lastCommitSha: input.commitSha,
+      errorMessage: undefined,
+    });
+
+    // Placeholder: actual incremental update logic will be wired in later.
+    await this.setStatus({
+      ...prev,
+      status: "synced",
+      lastCommitSha: input.commitSha,
+      lastSyncAt: new Date(),
+    });
+  }
+
+  private async setStatus(state: SyncState): Promise<void> {
+    this.memory.set(state);
+    if (!hasDatabase()) return;
+
+    try {
+      const sql = getDb();
+      await sql`
+        INSERT INTO knowledge_graph_sync (
+          repo_full_name,
+          last_commit_sha,
+          last_sync_at,
+          entity_count,
+          status,
+          error_message
+        ) VALUES (
+          ${state.repoFullName},
+          ${state.lastCommitSha},
+          ${state.lastSyncAt},
+          ${state.entityCount},
+          ${state.status},
+          ${state.errorMessage ?? null}
+        )
+        ON CONFLICT (repo_full_name) DO UPDATE SET
+          last_commit_sha = EXCLUDED.last_commit_sha,
+          last_sync_at = EXCLUDED.last_sync_at,
+          entity_count = EXCLUDED.entity_count,
+          status = EXCLUDED.status,
+          error_message = EXCLUDED.error_message,
+          updated_at = NOW()
+      `;
+    } catch (error) {
+      if (isPostgresRelationMissing(error)) return;
+      console.warn("[KnowledgeGraphSync] setStatus failed; state kept in memory", error);
+    }
+  }
+}
+
+export const knowledgeGraphSync = new KnowledgeGraphSyncService();

--- a/src/core/knowledge-graph/temporal-tracker.test.ts
+++ b/src/core/knowledge-graph/temporal-tracker.test.ts
@@ -21,7 +21,8 @@ function entity(partial: Partial<ResolvedEntity>): ResolvedEntity {
 describe("TemporalTracker", () => {
   it("records first version and returns current", async () => {
     const tracker = new TemporalTracker();
-    const v1 = await tracker.recordVersion(entity({ signature: "a()" }), "sha1");
+    const t1 = new Date("2024-01-01T00:00:00.000Z");
+    const v1 = await tracker.recordVersion(entity({ signature: "a()" }), "sha1", t1);
     expect(v1.version).toBe(1);
     expect(v1.validUntil).toBeNull();
     const current = await tracker.getCurrent("canon");
@@ -30,9 +31,10 @@ describe("TemporalTracker", () => {
 
   it("creates a new version when entity changes", async () => {
     const tracker = new TemporalTracker();
-    const v1 = await tracker.recordVersion(entity({ signature: "a()" }), "sha1");
-    await new Promise((r) => setTimeout(r, 5));
-    const v2 = await tracker.recordVersion(entity({ signature: "a(x)" }), "sha2");
+    const t1 = new Date("2024-01-01T00:00:00.000Z");
+    const t2 = new Date("2024-01-01T00:00:01.000Z");
+    const v1 = await tracker.recordVersion(entity({ signature: "a()" }), "sha1", t1);
+    const v2 = await tracker.recordVersion(entity({ signature: "a(x)" }), "sha2", t2);
     expect(v2.version).toBe(2);
     expect(v2.supersedes).toBe(v1.id);
     expect(v1.validUntil).not.toBeNull();
@@ -42,21 +44,23 @@ describe("TemporalTracker", () => {
 
   it("returns version at point in time", async () => {
     const tracker = new TemporalTracker();
-    const t0 = new Date();
-    const v1 = await tracker.recordVersion(entity({ signature: "a()" }), "sha1");
-    await new Promise((r) => setTimeout(r, 5));
-    const split = new Date();
-    const v2 = await tracker.recordVersion(entity({ signature: "a(x)" }), "sha2");
+    const t1 = new Date("2024-01-01T00:00:00.000Z");
+    const split = new Date("2024-01-01T00:00:01.000Z");
+    const t2 = new Date("2024-01-01T00:00:02.000Z");
+    const after = new Date("2024-01-01T00:00:03.000Z");
+    const v1 = await tracker.recordVersion(entity({ signature: "a()" }), "sha1", t1);
+    const v2 = await tracker.recordVersion(entity({ signature: "a(x)" }), "sha2", t2);
 
-    expect((await tracker.getAtTime("canon", t0))?.id).toBe(v1.id);
-    expect((await tracker.getAtTime("canon", split))?.id).toBe(v2.id);
+    expect((await tracker.getAtTime("canon", t1))?.id).toBe(v1.id);
+    expect((await tracker.getAtTime("canon", split))?.id).toBe(v1.id);
+    expect((await tracker.getAtTime("canon", after))?.id).toBe(v2.id);
   });
 
   it("can invalidate an entity", async () => {
     const tracker = new TemporalTracker();
-    const v1 = await tracker.recordVersion(entity({ signature: "a()" }), "sha1");
+    const t1 = new Date("2024-01-01T00:00:00.000Z");
+    const v1 = await tracker.recordVersion(entity({ signature: "a()" }), "sha1", t1);
     await tracker.invalidate(v1.id);
     expect(v1.validUntil).not.toBeNull();
   });
 });
-

--- a/src/core/knowledge-graph/temporal-tracker.ts
+++ b/src/core/knowledge-graph/temporal-tracker.ts
@@ -58,8 +58,12 @@ export class TemporalTracker {
   private byCanonical = new Map<string, TemporalEntity[]>();
   private byId = new Map<string, TemporalEntity>();
 
-  async recordVersion(entity: ResolvedEntity, commitSha: string): Promise<TemporalEntity> {
-    const now = new Date();
+  async recordVersion(
+    entity: ResolvedEntity,
+    commitSha: string,
+    recordedAt?: Date,
+  ): Promise<TemporalEntity> {
+    const now = recordedAt ?? new Date();
     const canonicalId = entity.canonicalId;
     const versions = this.byCanonical.get(canonicalId) ?? [];
     const current = [...versions].reverse().find((v) => v.validUntil === null) ?? null;
@@ -126,4 +130,3 @@ export class TemporalTracker {
     this.byId.set(entityId, v);
   }
 }
-

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -443,6 +443,26 @@ async function migrate() {
   await sql`CREATE INDEX IF NOT EXISTS idx_kgs_repo ON knowledge_graph_sync(repo_full_name)`;
   console.log("✅ Created knowledge graph tables");
 
+  // Add repo scoping for multi-repo deployments (v0.9)
+  await sql`
+    ALTER TABLE knowledge_entities
+    ADD COLUMN IF NOT EXISTS repo_full_name VARCHAR(255)
+  `;
+  await sql`CREATE INDEX IF NOT EXISTS idx_ke_repo ON knowledge_entities(repo_full_name)`;
+
+  await sql`
+    ALTER TABLE entity_relationships
+    ADD COLUMN IF NOT EXISTS repo_full_name VARCHAR(255)
+  `;
+  await sql`CREATE INDEX IF NOT EXISTS idx_er_repo ON entity_relationships(repo_full_name)`;
+
+  await sql`
+    ALTER TABLE invalidation_events
+    ADD COLUMN IF NOT EXISTS repo_full_name VARCHAR(255)
+  `;
+  await sql`CREATE INDEX IF NOT EXISTS idx_ie_repo ON invalidation_events(repo_full_name)`;
+  console.log("✅ Added knowledge graph repo scoping");
+
   console.log("\n✨ Migrations complete!");
 
   await sql.end();


### PR DESCRIPTION
Implements a minimal, feature-flagged Knowledge Graph sync skeleton: push webhook triggers incremental sync and API endpoints expose sync status/entities. Includes repo scoping columns for KG tables and stabilizes temporal tracker tests.\n\nCloses #237