### PR TITLE
feat: integrate knowledge graph with orchestrator

### DIFF
--- a/src/agents/coder.ts
+++ b/src/agents/coder.ts
@@ -11,6 +11,7 @@ interface CoderInput {
   plan: string[];
   targetFiles: string[];
   fileContents: Record<string, string>;
+  knowledgeGraphContext?: string;
   previousDiff?: string;
   lastError?: string;
   // Multi-file coordination (optional)
@@ -182,6 +183,8 @@ ${input.plan.map((p, i) => `${i + 1}. ${p}`).join("\n")}
 
 ## Target Files
 ${input.targetFiles.join(", ")}
+
+${input.knowledgeGraphContext ? `\n## Knowledge Graph Context (best-effort)\n${input.knowledgeGraphContext}\n` : ""}
 
 ## Current File Contents
 ${fileContentsStr}

--- a/src/agents/entity-extractor/types.ts
+++ b/src/agents/entity-extractor/types.ts
@@ -57,7 +57,16 @@ export class EntityExtractorAgent extends BaseAgent<
 
   constructor(config: EntityExtractorConfig = {}) {
     super(config);
-    this.supported = new Set(config.supportedLanguages ?? ["unknown"]);
+    this.supported = new Set(
+      config.supportedLanguages ?? [
+        "typescript",
+        "javascript",
+        "python",
+        "rust",
+        "go",
+        "unknown",
+      ],
+    );
   }
 
   async run(input: EntityExtractionInput): Promise<EntityExtractionResult> {
@@ -98,4 +107,3 @@ ${input.content}
     return { entities, language, filePath: input.filePath };
   }
 }
-

--- a/src/agents/fixer.ts
+++ b/src/agents/fixer.ts
@@ -7,6 +7,7 @@ interface FixerInput {
   currentDiff: string;
   errorLogs: string;
   fileContents: Record<string, string>;
+  knowledgeGraphContext?: string;
 }
 
 // Default fixer model - Kimi K2 Thinking for tool-oriented debugging
@@ -103,6 +104,8 @@ ${input.currentDiff}
 \`\`\`
 ${input.errorLogs}
 \`\`\`
+
+${input.knowledgeGraphContext ? `\n## Knowledge Graph Context (best-effort)\n${input.knowledgeGraphContext}\n` : ""}
 
 ## Current File Contents
 Note: depending on execution mode, these contents may reflect the base branch *before* the diff above is applied. Use \`currentDiff\` as the source of truth for the intended changes, and output a single complete diff that reaches the fixed final state.

--- a/src/core/knowledge-graph/knowledge-graph-service.test.ts
+++ b/src/core/knowledge-graph/knowledge-graph-service.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "bun:test";
+import { KnowledgeGraphService, type KnowledgeGraphExtractor } from "./knowledge-graph-service";
+import type { ExtractedEntity } from "./types";
+
+class MockExtractor implements KnowledgeGraphExtractor {
+  constructor(private map: Record<string, ExtractedEntity[]>) {}
+  async extractFromFile(filePath: string): Promise<ExtractedEntity[]> {
+    return this.map[filePath] ?? [];
+  }
+}
+
+function e(
+  partial: Partial<ExtractedEntity> & Pick<ExtractedEntity, "name" | "entityType" | "id">,
+): ExtractedEntity {
+  return {
+    id: partial.id,
+    name: partial.name,
+    entityType: partial.entityType,
+    filePath: partial.filePath ?? "src/a.ts",
+    signature: partial.signature ?? null,
+    content: partial.content ?? null,
+    metadata: partial.metadata,
+  };
+}
+
+describe("KnowledgeGraphService", () => {
+  it("enhanceContext returns a summary with dependencies", async () => {
+    const prev = process.env.ENABLE_KNOWLEDGE_GRAPH;
+    const extractor = new MockExtractor({
+      "src/a.ts": [
+        e({
+          id: "function:foo:src/a.ts",
+          name: "foo",
+          entityType: "function",
+          filePath: "src/a.ts",
+          content: "import { bar } from './b';\nexport function foo() { return bar(); }",
+        }),
+      ],
+      "src/b.ts": [
+        e({
+          id: "function:bar:src/b.ts",
+          name: "bar",
+          entityType: "function",
+          filePath: "src/b.ts",
+          content: "export function bar() { return 1; }",
+        }),
+      ],
+    });
+
+    const kg = new KnowledgeGraphService({ extractor });
+    process.env.ENABLE_KNOWLEDGE_GRAPH = "true";
+
+    const ctx = await kg.enhanceContext(
+      { githubRepo: "owner/repo" } as any,
+      { "src/a.ts": "x", "src/b.ts": "y" },
+    );
+
+    expect(ctx).not.toBeNull();
+    expect(ctx!.entities.length).toBe(2);
+    expect(ctx!.dependencies.length).toBeGreaterThanOrEqual(1);
+    expect(ctx!.summary).toContain("Entities:");
+    expect(ctx!.summary).toContain("Dependencies");
+    if (prev === undefined) delete process.env.ENABLE_KNOWLEDGE_GRAPH;
+    else process.env.ENABLE_KNOWLEDGE_GRAPH = prev;
+  });
+
+  it("analyzeImpact returns risk and changed files", async () => {
+    const prev = process.env.ENABLE_KNOWLEDGE_GRAPH;
+    const extractor = new MockExtractor({
+      "src/a.ts": [
+        e({
+          id: "function:foo:src/a.ts",
+          name: "foo",
+          entityType: "function",
+          filePath: "src/a.ts",
+          content: "export function foo() { return 1; }",
+        }),
+      ],
+    });
+
+    const kg = new KnowledgeGraphService({ extractor });
+    process.env.ENABLE_KNOWLEDGE_GRAPH = "true";
+
+    const analysis = await kg.analyzeImpact(
+      { githubRepo: "owner/repo" } as any,
+      "diff --git a/src/a.ts b/src/a.ts\n--- a/src/a.ts\n+++ b/src/a.ts\n@@ -1 +1 @@\n-x\n+y\n",
+      { "src/a.ts": "content" },
+    );
+
+    expect(analysis).not.toBeNull();
+    expect(analysis!.changedFiles).toEqual(["src/a.ts"]);
+    expect(["low", "medium", "high"]).toContain(analysis!.riskLevel);
+    if (prev === undefined) delete process.env.ENABLE_KNOWLEDGE_GRAPH;
+    else process.env.ENABLE_KNOWLEDGE_GRAPH = prev;
+  });
+});

--- a/src/core/knowledge-graph/knowledge-graph-service.ts
+++ b/src/core/knowledge-graph/knowledge-graph-service.ts
@@ -1,0 +1,306 @@
+import { createHash } from "node:crypto";
+import type { Task } from "../types";
+import { EntityExtractorAgent } from "../../agents/entity-extractor/types";
+import { EntityResolver } from "./entity-resolver";
+import { TemporalTracker, type TemporalEntity } from "./temporal-tracker";
+import {
+  MultiHopRetriever,
+  type TemporalRelationship,
+  type HopResult,
+} from "./multi-hop-retriever";
+import type { ExtractedEntity, ResolvedEntity, RelationshipKind } from "./types";
+import { knowledgeGraphSync } from "./sync-service";
+
+export type RiskLevel = "low" | "medium" | "high";
+
+export interface EnhancedKnowledgeContext {
+  entities: ResolvedEntity[];
+  dependencies: HopResult[];
+  recentChanges: TemporalEntity[];
+  impactRadius: number;
+  summary: string;
+}
+
+export interface ImpactAnalysis {
+  changedFiles: string[];
+  directEntities: ResolvedEntity[];
+  impactedEntities: HopResult[];
+  riskLevel: RiskLevel;
+  warnings: string[];
+}
+
+export interface KnowledgeGraphExtractor {
+  extractFromFile(filePath: string, content: string): Promise<ExtractedEntity[]>;
+}
+
+class AgentEntityExtractor implements KnowledgeGraphExtractor {
+  private agent: EntityExtractorAgent;
+
+  constructor() {
+    this.agent = new EntityExtractorAgent({
+      supportedLanguages: [
+        "typescript",
+        "javascript",
+        "python",
+        "rust",
+        "go",
+        "unknown",
+      ],
+    });
+  }
+
+  async extractFromFile(filePath: string, content: string): Promise<ExtractedEntity[]> {
+    const result = await this.agent.run({ filePath, content });
+    return result.entities;
+  }
+}
+
+function enabled(): boolean {
+  const v = process.env.ENABLE_KNOWLEDGE_GRAPH;
+  return v === "1" || v?.toLowerCase() === "true" || v?.toLowerCase() === "yes";
+}
+
+function stableId(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 32);
+}
+
+function extractChangedFilesFromDiff(diff: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+
+  for (const line of diff.split("\n")) {
+    const m = line.match(/^diff --git a\/(.+?) b\/(.+)\s*$/);
+    if (m) {
+      const path = m[2]!;
+      if (!seen.has(path)) {
+        seen.add(path);
+        out.push(path);
+      }
+    }
+  }
+
+  if (out.length > 0) return out;
+
+  for (const line of diff.split("\n")) {
+    const m = line.match(/^\+\+\+ b\/(.+)\s*$/);
+    if (!m) continue;
+    const path = m[1]!;
+    if (path === "/dev/null") continue;
+    if (!seen.has(path)) {
+      seen.add(path);
+      out.push(path);
+    }
+  }
+
+  return out;
+}
+
+function formatEntity(e: ResolvedEntity): string {
+  const fp = e.filePath ? ` (${e.filePath})` : "";
+  return `${e.entityType}:${e.name}${fp}`;
+}
+
+function relationshipToTemporal(
+  type: RelationshipKind,
+): Exclude<TemporalRelationship["relationshipType"], "used_by"> {
+  return type;
+}
+
+export class KnowledgeGraphService {
+  private extractor: KnowledgeGraphExtractor;
+  private resolver: EntityResolver;
+  private tracker: TemporalTracker;
+
+  constructor(opts?: { extractor?: KnowledgeGraphExtractor }) {
+    this.extractor = opts?.extractor ?? new AgentEntityExtractor();
+    this.resolver = new EntityResolver();
+    this.tracker = new TemporalTracker();
+  }
+
+  enabled(): boolean {
+    return enabled();
+  }
+
+  async enhanceContext(
+    task: Pick<Task, "githubRepo">,
+    fileContents: Record<string, string>,
+  ): Promise<EnhancedKnowledgeContext | null> {
+    if (!this.enabled()) return null;
+
+    const extracted: ExtractedEntity[] = [];
+    for (const [filePath, content] of Object.entries(fileContents)) {
+      try {
+        extracted.push(...(await this.extractor.extractFromFile(filePath, content)));
+      } catch {
+        // Best-effort: skip extraction errors for a single file
+      }
+    }
+
+    const resolved = this.resolver.resolve(extracted, []);
+    const { entities, relationships, currentByCanonical } =
+      await this.materializeTemporalGraph(resolved, "working");
+    const retriever = new MultiHopRetriever({ entities, relationships });
+
+    const targetEntityIds = new Set<string>();
+    for (const e of resolved) {
+      if (!e.filePath) continue;
+      if (!fileContents[e.filePath]) continue;
+      const cur = currentByCanonical.get(e.canonicalId);
+      if (cur) targetEntityIds.add(cur.id);
+    }
+
+    const dependencies: HopResult[] = [];
+    const depSeen = new Set<string>();
+    for (const id of targetEntityIds) {
+      const deps = await retriever.findDependencies(id, this.maxHops());
+      for (const d of deps) {
+        if (depSeen.has(d.entity.id)) continue;
+        depSeen.add(d.entity.id);
+        dependencies.push(d);
+      }
+    }
+
+    const summaryLines: string[] = [];
+    summaryLines.push(
+      `Entities: ${resolved.slice(0, 25).map(formatEntity).join(", ")}${resolved.length > 25 ? "…" : ""}`,
+    );
+    if (dependencies.length > 0) {
+      summaryLines.push(
+        `Dependencies (maxHops=${this.maxHops()}): ${dependencies
+          .slice(0, 25)
+          .map((d) => formatEntity(d.entity.entity))
+          .join(", ")}${dependencies.length > 25 ? "…" : ""}`,
+      );
+    }
+
+    return {
+      entities: resolved,
+      dependencies,
+      recentChanges: [],
+      impactRadius: dependencies.length,
+      summary: summaryLines.join("\n"),
+    };
+  }
+
+  async analyzeImpact(
+    task: Pick<Task, "githubRepo">,
+    diff: string,
+    fileContents: Record<string, string>,
+  ): Promise<ImpactAnalysis | null> {
+    if (!this.enabled()) return null;
+
+    const changedFiles = extractChangedFilesFromDiff(diff);
+    const extracted: ExtractedEntity[] = [];
+    for (const filePath of changedFiles) {
+      const content = fileContents[filePath];
+      if (!content) continue;
+      try {
+        extracted.push(...(await this.extractor.extractFromFile(filePath, content)));
+      } catch {
+        // Best-effort
+      }
+    }
+
+    const resolved = this.resolver.resolve(extracted, []);
+    const { entities, relationships, currentByCanonical } =
+      await this.materializeTemporalGraph(resolved, "working");
+    const retriever = new MultiHopRetriever({ entities, relationships });
+
+    const impacted: HopResult[] = [];
+    const seen = new Set<string>();
+    for (const e of resolved) {
+      const cur = currentByCanonical.get(e.canonicalId);
+      if (!cur) continue;
+      const results = await retriever.findImpact(cur.id, this.maxHops());
+      for (const r of results) {
+        if (seen.has(r.entity.id)) continue;
+        seen.add(r.entity.id);
+        impacted.push(r);
+      }
+    }
+
+    const riskLevel = this.calculateRisk(changedFiles.length, resolved.length, impacted.length);
+    const warnings: string[] = [];
+    if (riskLevel !== "low") {
+      warnings.push(
+        `Potentially ${riskLevel} impact: ${resolved.length} direct entities, ${impacted.length} impacted entities (maxHops=${this.maxHops()}).`,
+      );
+    }
+
+    return {
+      changedFiles,
+      directEntities: resolved,
+      impactedEntities: impacted,
+      riskLevel,
+      warnings,
+    };
+  }
+
+  async onCommitApplied(task: Pick<Task, "githubRepo">, diff: string, commitSha: string): Promise<void> {
+    if (!this.enabled()) return;
+    if (!knowledgeGraphSync.enabled()) return;
+
+    const changedFiles = extractChangedFilesFromDiff(diff);
+    void knowledgeGraphSync.triggerIncrementalSync({
+      repoFullName: task.githubRepo,
+      commitSha,
+      changedFiles,
+    });
+  }
+
+  private maxHops(): number {
+    const v = parseInt(process.env.KNOWLEDGE_GRAPH_MAX_HOPS || "3", 10);
+    return Number.isFinite(v) && v > 0 ? v : 3;
+  }
+
+  private calculateRisk(
+    changedFiles: number,
+    directEntities: number,
+    impactedEntities: number,
+  ): RiskLevel {
+    if (changedFiles >= 10) return "high";
+    if (impactedEntities >= 25) return "high";
+    if (directEntities >= 10 || impactedEntities >= 10) return "medium";
+    return "low";
+  }
+
+  private async materializeTemporalGraph(
+    entities: ResolvedEntity[],
+    commitSha: string,
+  ): Promise<{
+    entities: TemporalEntity[];
+    relationships: TemporalRelationship[];
+    currentByCanonical: Map<string, TemporalEntity>;
+  }> {
+    const now = new Date();
+    const temporalEntities: TemporalEntity[] = [];
+    const currentByCanonical = new Map<string, TemporalEntity>();
+
+    for (const e of entities) {
+      const t = await this.tracker.recordVersion(e, commitSha, now);
+      temporalEntities.push(t);
+      currentByCanonical.set(e.canonicalId, t);
+    }
+
+    const relationships: TemporalRelationship[] = [];
+    for (const e of entities) {
+      const source = currentByCanonical.get(e.canonicalId);
+      if (!source) continue;
+      for (const rel of e.relationships ?? []) {
+        const target = currentByCanonical.get(rel.targetId);
+        if (!target) continue;
+        relationships.push({
+          id: stableId(`${source.id}:${rel.type}:${target.id}`),
+          sourceId: source.id,
+          targetId: target.id,
+          relationshipType: relationshipToTemporal(rel.type),
+          validFrom: now,
+          validUntil: null,
+        });
+      }
+    }
+
+    return { entities: temporalEntities, relationships, currentByCanonical };
+  }
+}
+


### PR DESCRIPTION
Adds a feature-flagged Knowledge Graph integration layer for AutoDev:\n- Pre-coding/fixing: injects best-effort KG context into Coder/Fixer prompts\n- Pre-apply: runs a lightweight impact analysis and logs warnings\n- Post-apply: triggers incremental KG sync when enabled\n- Adds a small service + tests (no DB required)\n\nEnv: ENABLE_KNOWLEDGE_GRAPH=true, KNOWLEDGE_GRAPH_MAX_HOPS=3\n\nCloses #236