### PR TITLE
feat: Add syntax validation to prevent malformed LLM output (#309)

### DIFF
--- a/src/core/syntax-validator.test.ts
+++ b/src/core/syntax-validator.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, expect } from "bun:test";
+import {
+  checkBalancedBraces,
+  checkTruncation,
+  checkDuplicateDeclarations,
+  checkCorruptedPatterns,
+  validateSyntax,
+  validateSyntaxBatch,
+} from "./syntax-validator";
+
+describe("checkBalancedBraces", () => {
+  it("passes for balanced code", () => {
+    const code = `
+function test() {
+  const obj = { a: 1, b: [1, 2, 3] };
+  if (true) {
+    console.log("hello");
+  }
+}
+`;
+    const result = checkBalancedBraces(code, "test.ts");
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("detects unclosed braces", () => {
+    const code = `
+function test() {
+  if (true) {
+    console.log("hello");
+  // missing closing brace
+}
+`;
+    const result = checkBalancedBraces(code, "test.ts");
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("unclosed brace"))).toBe(true);
+  });
+
+  it("detects unclosed brackets", () => {
+    const code = `
+const arr = [1, 2, 3;
+`;
+    const result = checkBalancedBraces(code, "test.ts");
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("unclosed bracket"))).toBe(true);
+  });
+
+  it("detects unclosed parentheses", () => {
+    const code = `
+function test(a, b {
+  return a + b;
+}
+`;
+    const result = checkBalancedBraces(code, "test.ts");
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("unclosed parenthesis"))).toBe(true);
+  });
+
+  it("ignores braces in strings", () => {
+    const code = `
+const str = "this has { and } in it";
+const str2 = 'also { here }';
+`;
+    const result = checkBalancedBraces(code, "test.ts");
+    expect(result.valid).toBe(true);
+  });
+
+  it("ignores braces in comments", () => {
+    const code = `
+// this has { unclosed brace
+/* and this { too } */
+function valid() {
+  return true;
+}
+`;
+    const result = checkBalancedBraces(code, "test.ts");
+    expect(result.valid).toBe(true);
+  });
+
+  it("handles template literals", () => {
+    const code = `
+const template = \`Hello \${name}, you have \${count} items\`;
+`;
+    const result = checkBalancedBraces(code, "test.ts");
+    expect(result.valid).toBe(true);
+  });
+
+  it("detects unclosed template literal", () => {
+    const code = `
+const template = \`Hello \${name
+`;
+    const result = checkBalancedBraces(code, "test.ts");
+    expect(result.valid).toBe(false);
+  });
+
+  it("detects unclosed multi-line comment", () => {
+    const code = `
+/* This comment is never closed
+function test() {
+  return true;
+}
+`;
+    const result = checkBalancedBraces(code, "test.ts");
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("multi-line comment"))).toBe(true);
+  });
+});
+
+describe("checkTruncation", () => {
+  it("passes for complete code", () => {
+    const code = `
+export function test() {
+  return true;
+}
+`;
+    const result = checkTruncation(code, "test.ts");
+    expect(result.valid).toBe(true);
+  });
+
+  it("warns on incomplete statement at end", () => {
+    const code = `
+export function test() {
+  const value =`;
+    const result = checkTruncation(code, "test.ts");
+    // This is a warning, not error
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it("detects truncation markers", () => {
+    const code = `
+export function test() {
+  // [truncated]
+}
+`;
+    const result = checkTruncation(code, "test.ts");
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("truncation marker"))).toBe(true);
+  });
+
+  it("detects LLM continuation markers", () => {
+    const code = `
+export function test() {
+  // ... rest of code
+}
+`;
+    const result = checkTruncation(code, "test.ts");
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("checkDuplicateDeclarations", () => {
+  it("passes for unique declarations", () => {
+    const code = `
+export function foo() {}
+export function bar() {}
+export const baz = 1;
+`;
+    const result = checkDuplicateDeclarations(code, "test.ts");
+    expect(result.valid).toBe(true);
+  });
+
+  it("detects duplicate function declarations", () => {
+    const code = `
+export function test() {
+  return 1;
+}
+
+export function test() {
+  return 2;
+}
+`;
+    const result = checkDuplicateDeclarations(code, "test.ts");
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('Duplicate declaration of "test"'))).toBe(true);
+  });
+
+  it("detects duplicate class declarations", () => {
+    const code = `
+export class MyClass {}
+export class MyClass {}
+`;
+    const result = checkDuplicateDeclarations(code, "test.ts");
+    expect(result.valid).toBe(false);
+  });
+
+  it("detects duplicate interface declarations", () => {
+    const code = `
+export interface Config {}
+export interface Config {}
+`;
+    const result = checkDuplicateDeclarations(code, "test.ts");
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("checkCorruptedPatterns", () => {
+  it("passes for clean code", () => {
+    const code = `
+export function test() {
+  const a = 1;
+  const b = 2;
+  return a === b;
+}
+`;
+    const result = checkCorruptedPatterns(code, "test.ts");
+    expect(result.valid).toBe(true);
+  });
+
+  it("detects malformed equality operator", () => {
+    const code = `
+if (a = = b) {
+  return true;
+}
+`;
+    const result = checkCorruptedPatterns(code, "test.ts");
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("equality operator"))).toBe(true);
+  });
+
+  it("warns on double semicolons", () => {
+    const code = `
+const a = 1;;
+`;
+    const result = checkCorruptedPatterns(code, "test.ts");
+    expect(result.warnings.some((e) => e.includes("semicolon"))).toBe(true);
+  });
+});
+
+describe("validateSyntax", () => {
+  it("validates complete TypeScript file", () => {
+    const code = `
+import { z } from "zod";
+
+export interface Config {
+  name: string;
+  value: number;
+}
+
+export function createConfig(name: string): Config {
+  return {
+    name,
+    value: 42,
+  };
+}
+
+export class ConfigManager {
+  private config: Config;
+
+  constructor(config: Config) {
+    this.config = config;
+  }
+
+  get(): Config {
+    return this.config;
+  }
+}
+`;
+    const result = validateSyntax(code, "config.ts");
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("catches multiple issues", () => {
+    const code = `
+export function test() {
+  const obj = {
+    // [truncated]
+`;
+    const result = validateSyntax(code, "test.ts");
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it("skips non-JS/TS files", () => {
+    const code = `
+This is not valid code { [ (
+`;
+    const result = validateSyntax(code, "readme.md");
+    expect(result.valid).toBe(true);
+  });
+
+  it("validates JSX files", () => {
+    const code = `
+export function Component() {
+  return <div>Hello</div>;
+}
+`;
+    const result = validateSyntax(code, "Component.tsx");
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("validateSyntaxBatch", () => {
+  it("validates multiple files", () => {
+    const files = [
+      { path: "a.ts", content: "export const a = 1;" },
+      { path: "b.ts", content: "export const b = 2;" },
+    ];
+    const result = validateSyntaxBatch(files);
+    expect(result.valid).toBe(true);
+  });
+
+  it("catches errors in any file", () => {
+    const files = [
+      { path: "a.ts", content: "export const a = 1;" },
+      { path: "b.ts", content: "export function broken() {" }, // Unclosed
+    ];
+    const result = validateSyntaxBatch(files);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("b.ts"))).toBe(true);
+  });
+});
+
+describe("real-world corruption patterns", () => {
+  it("detects the PR #306 corruption pattern", () => {
+    // Simulating the kind of corruption seen in PR #306
+    const code = `
+import { z } from "zod";
+import type { MCPToolDefinition, ToolHandler } from "../types.js";
+
+export const memoryTool: MCPToolDefinition = {
+  description: "Query AutoDev memory for a repository",
+  inputSchema: {
+    type: "object",
++++ b/src/mcp/tools/memory.ts
+    properties: {
+      repo: {
+`;
+    const result = validateSyntax(code, "memory.ts");
+    expect(result.valid).toBe(false);
+  });
+
+  it("detects code with diff markers embedded", () => {
+    const code = `
+export function test() {
+--- a/src/test.ts
++++ b/src/test.ts
+  return true;
+}
+`;
+    // This should be caught by the diff-validator, but syntax check should also flag it
+    const result = checkBalancedBraces(code, "test.ts");
+    // The braces are still balanced, but other validators might catch this
+    expect(result.valid).toBe(true);
+  });
+
+  it("detects severely truncated code", () => {
+    const code = `
+import { z } from "zod";
+
+export interface Config {
+  name: string;
+  options: {
+    enabled: boolean;
+    settings: {
+      // Code was cut off here`;
+    const result = validateSyntax(code, "config.ts");
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("unclosed"))).toBe(true);
+  });
+});

--- a/src/core/syntax-validator.ts
+++ b/src/core/syntax-validator.ts
@@ -1,0 +1,462 @@
+/**
+ * Syntax Validator
+ *
+ * Validates code syntax before pushing to GitHub.
+ * Catches common LLM output errors:
+ * - Unbalanced braces/brackets/parentheses
+ * - Truncated code
+ * - Malformed TypeScript/JavaScript
+ *
+ * Issue #309 - Prevent AutoDev from generating malformed code
+ */
+
+export interface SyntaxValidationResult {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+interface BraceCount {
+  open: number;
+  close: number;
+  positions: { char: string; line: number; col: number }[];
+}
+
+/**
+ * Check for balanced braces, brackets, and parentheses
+ */
+export function checkBalancedBraces(
+  content: string,
+  filePath: string,
+): SyntaxValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const braces: BraceCount = { open: 0, close: 0, positions: [] };
+  const brackets: BraceCount = { open: 0, close: 0, positions: [] };
+  const parens: BraceCount = { open: 0, close: 0, positions: [] };
+  const templateLiterals: BraceCount = { open: 0, close: 0, positions: [] };
+
+  let inString = false;
+  let stringChar = "";
+  let inTemplateString = false;
+  let inComment = false;
+  let inMultilineComment = false;
+  let line = 1;
+  let col = 0;
+
+  for (let i = 0; i < content.length; i++) {
+    const char = content[i];
+    const prevChar = content[i - 1] || "";
+    const nextChar = content[i + 1] || "";
+
+    col++;
+
+    if (char === "\n") {
+      line++;
+      col = 0;
+      inComment = false;
+      continue;
+    }
+
+    // Handle multi-line comments
+    if (!inString && !inTemplateString) {
+      if (char === "/" && nextChar === "*" && !inMultilineComment) {
+        inMultilineComment = true;
+        continue;
+      }
+      if (char === "*" && nextChar === "/" && inMultilineComment) {
+        inMultilineComment = false;
+        i++; // Skip the /
+        continue;
+      }
+      if (inMultilineComment) continue;
+
+      // Handle single-line comments
+      if (char === "/" && nextChar === "/") {
+        inComment = true;
+        continue;
+      }
+      if (inComment) continue;
+    }
+
+    // Handle strings
+    if (!inComment && !inMultilineComment) {
+      if (
+        (char === '"' || char === "'") &&
+        prevChar !== "\\" &&
+        !inTemplateString
+      ) {
+        if (inString && stringChar === char) {
+          inString = false;
+          stringChar = "";
+        } else if (!inString) {
+          inString = true;
+          stringChar = char;
+        }
+        continue;
+      }
+
+      // Handle template literals
+      if (char === "`" && prevChar !== "\\") {
+        if (inTemplateString) {
+          inTemplateString = false;
+          templateLiterals.close++;
+        } else {
+          inTemplateString = true;
+          templateLiterals.open++;
+        }
+        continue;
+      }
+
+      if (inString) continue;
+
+      // Template literal interpolation ${...}
+      if (inTemplateString && char === "$" && nextChar === "{") {
+        // Skip the ${, will be handled as regular brace
+        continue;
+      }
+    }
+
+    // Count braces (outside of strings and comments)
+    if (!inString && !inComment && !inMultilineComment) {
+      switch (char) {
+        case "{":
+          braces.open++;
+          braces.positions.push({ char: "{", line, col });
+          break;
+        case "}":
+          braces.close++;
+          braces.positions.push({ char: "}", line, col });
+          break;
+        case "[":
+          brackets.open++;
+          brackets.positions.push({ char: "[", line, col });
+          break;
+        case "]":
+          brackets.close++;
+          brackets.positions.push({ char: "]", line, col });
+          break;
+        case "(":
+          parens.open++;
+          parens.positions.push({ char: "(", line, col });
+          break;
+        case ")":
+          parens.close++;
+          parens.positions.push({ char: ")", line, col });
+          break;
+      }
+    }
+  }
+
+  // Check for unbalanced braces
+  if (braces.open !== braces.close) {
+    const diff = braces.open - braces.close;
+    if (diff > 0) {
+      errors.push(
+        `${filePath}: ${diff} unclosed brace(s) '{' - code may be truncated`,
+      );
+    } else {
+      errors.push(
+        `${filePath}: ${-diff} extra closing brace(s) '}' - code may be malformed`,
+      );
+    }
+  }
+
+  if (brackets.open !== brackets.close) {
+    const diff = brackets.open - brackets.close;
+    if (diff > 0) {
+      errors.push(
+        `${filePath}: ${diff} unclosed bracket(s) '[' - code may be truncated`,
+      );
+    } else {
+      errors.push(
+        `${filePath}: ${-diff} extra closing bracket(s) ']' - code may be malformed`,
+      );
+    }
+  }
+
+  if (parens.open !== parens.close) {
+    const diff = parens.open - parens.close;
+    if (diff > 0) {
+      errors.push(
+        `${filePath}: ${diff} unclosed parenthesis '(' - code may be truncated`,
+      );
+    } else {
+      errors.push(
+        `${filePath}: ${-diff} extra closing parenthesis ')' - code may be malformed`,
+      );
+    }
+  }
+
+  // Check for unclosed template literals
+  if (templateLiterals.open !== templateLiterals.close) {
+    errors.push(`${filePath}: Unclosed template literal`);
+  }
+
+  // Check for unclosed strings (if we ended in a string)
+  if (inString) {
+    errors.push(`${filePath}: Unclosed string literal`);
+  }
+
+  // Check for unclosed multi-line comment
+  if (inMultilineComment) {
+    errors.push(`${filePath}: Unclosed multi-line comment`);
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+/**
+ * Check for common truncation patterns
+ */
+export function checkTruncation(
+  content: string,
+  filePath: string,
+): SyntaxValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const lines = content.split("\n");
+  const lastLine = lines[lines.length - 1]?.trim() || "";
+  const lastFewLines = lines.slice(-5).join("\n");
+
+  // Check for abrupt endings
+  const truncationPatterns = [
+    // Incomplete statements
+    /,\s*$/,
+    /\(\s*$/,
+    /\[\s*$/,
+    /{\s*$/,
+    /=>\s*$/,
+    /[^=!<>]=\s*$/, // Assignment that's not ==, !=, <=, >=
+    /:\s*$/,
+    /\+\s*$/,
+    /-\s*$/,
+    /\*\s*$/,
+    /\/\s*$/,
+    /&&\s*$/,
+    /\|\|\s*$/,
+    /\?\s*$/,
+  ];
+
+  for (const pattern of truncationPatterns) {
+    if (pattern.test(lastLine) && lastLine.length > 2) {
+      warnings.push(
+        `${filePath}: File ends with incomplete statement: "${lastLine.slice(-20)}"`,
+      );
+      break;
+    }
+  }
+
+  // Check for "..." or "[truncated]" markers
+  if (
+    content.includes("...") &&
+    (lastFewLines.includes("// ...") ||
+      lastFewLines.includes("/* ... */") ||
+      lastFewLines.includes("..."))
+  ) {
+    warnings.push(`${filePath}: File may contain truncation markers (...)`);
+  }
+
+  // Check for common LLM truncation patterns
+  const llmTruncationMarkers = [
+    "[truncated]",
+    "[continued]",
+    "[rest of code]",
+    "// More code here",
+    "// ... rest of",
+    "// TODO: complete",
+    "/* More */",
+  ];
+
+  for (const marker of llmTruncationMarkers) {
+    if (content.toLowerCase().includes(marker.toLowerCase())) {
+      errors.push(`${filePath}: Contains truncation marker: "${marker}"`);
+    }
+  }
+
+  // Check for very short files that should be longer
+  if (
+    (filePath.endsWith(".ts") || filePath.endsWith(".tsx")) &&
+    content.length < 50 &&
+    !content.includes("export") &&
+    !content.includes("//")
+  ) {
+    warnings.push(
+      `${filePath}: Suspiciously short TypeScript file (${content.length} chars)`,
+    );
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+/**
+ * Check for duplicate declarations that might indicate corrupted merge
+ */
+export function checkDuplicateDeclarations(
+  content: string,
+  filePath: string,
+): SyntaxValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // Find all function/class/const/let/var declarations
+  const declarationPatterns = [
+    /^export\s+(async\s+)?function\s+(\w+)/gm,
+    /^export\s+class\s+(\w+)/gm,
+    /^export\s+const\s+(\w+)/gm,
+    /^export\s+interface\s+(\w+)/gm,
+    /^export\s+type\s+(\w+)/gm,
+    /^(async\s+)?function\s+(\w+)/gm,
+    /^class\s+(\w+)/gm,
+    /^const\s+(\w+)\s*=/gm,
+    /^let\s+(\w+)\s*=/gm,
+    /^interface\s+(\w+)/gm,
+    /^type\s+(\w+)\s*=/gm,
+  ];
+
+  const declarations = new Map<string, number>();
+
+  for (const pattern of declarationPatterns) {
+    let match;
+    while ((match = pattern.exec(content)) !== null) {
+      // Get the last capture group (the name)
+      const name = match[match.length - 1];
+      if (name) {
+        declarations.set(name, (declarations.get(name) || 0) + 1);
+      }
+    }
+  }
+
+  // Check for duplicates
+  for (const [name, count] of declarations) {
+    if (count > 1) {
+      errors.push(
+        `${filePath}: Duplicate declaration of "${name}" (${count} times) - possible code corruption`,
+      );
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+/**
+ * Check for syntax patterns that indicate corrupted code
+ */
+export function checkCorruptedPatterns(
+  content: string,
+  filePath: string,
+): SyntaxValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const lines = content.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineNum = i + 1;
+
+    // Pattern: Multiple semicolons in a row (;;)
+    if (line.includes(";;") && !line.includes("for")) {
+      warnings.push(`${filePath}:${lineNum}: Double semicolon detected`);
+    }
+
+    // Pattern: = = instead of ==
+    if (line.includes("= =") || line.includes("= = =")) {
+      errors.push(`${filePath}:${lineNum}: Malformed equality operator`);
+    }
+
+    // Pattern: Unclosed JSX/TSX tags on a single line
+    if (
+      (filePath.endsWith(".tsx") || filePath.endsWith(".jsx")) &&
+      line.includes("<") &&
+      !line.includes(">") &&
+      !line.includes("=>") &&
+      !line.match(/<\w+$/) // Allow tags that continue on next line
+    ) {
+      // Only warn if it looks like a tag
+      if (line.match(/<[A-Z]\w*/)) {
+        warnings.push(`${filePath}:${lineNum}: Possibly unclosed JSX tag`);
+      }
+    }
+
+    // Pattern: Import statement without from
+    if (
+      line.startsWith("import ") &&
+      !line.includes("from") &&
+      !line.includes("type") &&
+      !line.endsWith("{") &&
+      !line.trim().endsWith(",")
+    ) {
+      warnings.push(`${filePath}:${lineNum}: Incomplete import statement`);
+    }
+
+    // Pattern: Hanging operators at start of line (might be valid, but often indicates issues)
+    if (line.match(/^\s*[+\-*/%&|^]=?\s*[^=]/)) {
+      // This is often valid for line continuation, so just warn
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+/**
+ * Main validation function - runs all checks
+ */
+export function validateSyntax(
+  content: string,
+  filePath: string,
+): SyntaxValidationResult {
+  const allErrors: string[] = [];
+  const allWarnings: string[] = [];
+
+  // Only validate TypeScript/JavaScript files
+  const supportedExtensions = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
+  const ext = filePath.slice(filePath.lastIndexOf("."));
+
+  if (!supportedExtensions.includes(ext)) {
+    return { valid: true, errors: [], warnings: [] };
+  }
+
+  // Run all checks
+  const checks = [
+    checkBalancedBraces(content, filePath),
+    checkTruncation(content, filePath),
+    checkDuplicateDeclarations(content, filePath),
+    checkCorruptedPatterns(content, filePath),
+  ];
+
+  for (const result of checks) {
+    allErrors.push(...result.errors);
+    allWarnings.push(...result.warnings);
+  }
+
+  return {
+    valid: allErrors.length === 0,
+    errors: allErrors,
+    warnings: allWarnings,
+  };
+}
+
+/**
+ * Validate multiple files
+ */
+export function validateSyntaxBatch(
+  files: { path: string; content: string }[],
+): SyntaxValidationResult {
+  const allErrors: string[] = [];
+  const allWarnings: string[] = [];
+
+  for (const file of files) {
+    const result = validateSyntax(file.content, file.path);
+    allErrors.push(...result.errors);
+    allWarnings.push(...result.warnings);
+  }
+
+  return {
+    valid: allErrors.length === 0,
+    errors: allErrors,
+    warnings: allWarnings,
+  };
+}


### PR DESCRIPTION
## Summary

Add pre-push syntax validation to catch common LLM output errors before they reach GitHub. This prevents the issues seen in PRs #305 and #306 where AutoDev generated malformed code with 50+ TypeScript errors.

## Changes

### New Files
- `src/core/syntax-validator.ts` - Core validation functions
- `src/core/syntax-validator.test.ts` - Comprehensive tests (29 tests)

### Modified Files
- `src/core/orchestrator.ts` - Integrated validation in `validateAndApplyDiff()`

## Validation Checks

1. **Balanced Braces** - Detects unclosed `{}`, `[]`, `()`
2. **Truncation Detection** - Catches incomplete statements, LLM markers like `[truncated]`
3. **Duplicate Declarations** - Finds duplicate function/class/const declarations
4. **Corrupted Patterns** - Detects malformed operators like `= =` instead of `==`

## Integration

Validation runs in `validateAndApplyDiff()` **before** the expensive typecheck:
- Errors trigger fixer with helpful context
- Warnings are logged but don't block
- Non-JS/TS files are skipped

## Test Results

```
230 pass, 0 fail
```

Closes #309